### PR TITLE
[Question] Disallow regular expression conversion between some tags

### DIFF
--- a/MarkdownToBBCode.py
+++ b/MarkdownToBBCode.py
@@ -60,7 +60,7 @@ class MarkdowntobbcodeCommand(sublime_plugin.TextCommand):
 		# Bold and italic
 		#
 		s = re.sub(r"_{2}([\s\S]+?)_{2}", "[b]\\1[/b]", s)  # __Bold__
-		s = re.sub(r"_([^_]+?)_", "[i]\\1[/i]", s)   		# _Italic_ Needs hack (?<=\s), because _ symbol often use in URLs
+		s = re.sub(r"_([^_]+?)_", "[i]\\1[/i]", s)   	    # _Italic_ Needs hack (?<=\s), because _ symbol often use in URLs
 		s = re.sub(r"\*{2}([\s\S]+?)\*{2}", "[b]\\1[/b]", s)# **Bold**
 		s = re.sub(r"\*([^\*]+?)\*", "[i]\\1[/i]", s)       # *Italic*.
 		#


### PR DESCRIPTION
(In your fork repository I can not to write issues so I write here.)

Thanks for interest to plugin! Plugin work correct in most cases, but not work correct, for example, if in converted code or link we have `_` or `*` symbols.

I not get answer in [**my question on Stack Overflow**](http://stackoverflow.com/q/40072106/5951529). See details in that question. I'm not a Python programmer, if you know, how realized in Python algorithm of expected behavior, it would be nice.

Thanks.

